### PR TITLE
SG2042: spinlock: Fix deadlock issue

### DIFF
--- a/include/sbi/riscv_barrier.h
+++ b/include/sbi/riscv_barrier.h
@@ -44,11 +44,20 @@
 
 /* clang-format on */
 
+#ifdef CONFIG_PLATFORM_SOPHGO_MANGO
+#define __smp_store_release(p, v)   \
+	do {                        \
+		RISCV_FENCE(rw, w); \
+		*(p) = (v);         \
+		RISCV_FENCE(w, rw); \
+	} while (0)
+#else
 #define __smp_store_release(p, v)   \
 	do {                        \
 		RISCV_FENCE(rw, w); \
 		*(p) = (v);         \
 	} while (0)
+#endif
 
 #define __smp_load_acquire(p)            \
 	({                               \


### PR DESCRIPTION
This problem was found on sg2042 server platform with the litmus test.

This patch is based on Guo Ren's patch [1].

[1] https://github.com/c-sky/csky-linux/commit/c53925298d15b1d7aac736766ba31116d1c03ba3

riscv: qspinlock: errata: Add ERRATA_THEAD_WRITE_ONCE fixup The early version of T-Head C9xx cores has a store merge buffer delay problem. The store merge buffer could improve the store queue performance by merging multi-store requests, but when there are not continued store requests, the prior single store request would be waiting in the store queue for a long time. That would cause significant problems for communication between multi-cores. This problem was found on sg2042 & th1520 platforms with the qspinlock lock torture test.

So appending a fence w.o could immediately flush the store merge buffer and let other cores see the write result.

This will apply the WRITE_ONCE errata to handle the non-standard behavior via appending a fence w.o instruction for WRITE_ONCE().