### PR TITLE
fix T-HEAD c9xx cpu softlock

### DIFF
--- a/lib/sbi/sbi_pmu.c
+++ b/lib/sbi/sbi_pmu.c
@@ -337,8 +337,11 @@ static int pmu_ctr_start_hw(uint32_t cidx, uint64_t ival, bool ival_update)
 	if (cidx >= num_hw_ctrs || cidx == 1)
 		return SBI_EINVAL;
 
-	if (sbi_hart_priv_version(scratch) < SBI_HART_PRIV_VER_1_11)
-		goto skip_inhibit_update;
+	if (sbi_hart_priv_version(scratch) < SBI_HART_PRIV_VER_1_11) {
+		if (ival_update)
+			pmu_ctr_write_hw(cidx, ival);
+		return 0;
+	}
 
 	/*
 	 * Some of the hardware may not support mcountinhibit but perf stat
@@ -354,11 +357,11 @@ static int pmu_ctr_start_hw(uint32_t cidx, uint64_t ival, bool ival_update)
 		pmu_ctr_enable_irq_hw(cidx);
 	if (pmu_dev && pmu_dev->hw_counter_enable_irq)
 		pmu_dev->hw_counter_enable_irq(cidx);
-	csr_write(CSR_MCOUNTINHIBIT, mctr_inhbt);
 
-skip_inhibit_update:
 	if (ival_update)
 		pmu_ctr_write_hw(cidx, ival);
+
+	csr_write(CSR_MCOUNTINHIBIT, mctr_inhbt);
 
 	return 0;
 }

--- a/platform/generic/allwinner/sun20i-d1.c
+++ b/platform/generic/allwinner/sun20i-d1.c
@@ -239,8 +239,16 @@ static void thead_c9xx_pmu_ctr_enable_irq(uint32_t ctr_idx)
 	 * Otherwise, there will be race conditions where we may clear the bit
 	 * the software is yet to handle the interrupt.
 	 */
-	if (!(mip_val & THEAD_C9XX_MIP_MOIP))
+	if (mip_val & THEAD_C9XX_MIP_MOIP)
 		csr_clear(THEAD_C9XX_CSR_MCOUNTEROF, BIT(ctr_idx));
+
+	/**
+	 * This register is described in c9xx document as the control register
+	 * for enabling writes to the superuser state counter. However, if the
+	 * corresponding bit is not set to 1, scounterof will always read as 0
+	 * when the counter register overflows.
+	 */
+	csr_set(THEAD_C9XX_CSR_MCOUNTERWEN, BIT(ctr_idx));
 
 	/**
 	 * SSCOFPMF uses the OF bit for enabling/disabling the interrupt,
@@ -252,6 +260,7 @@ static void thead_c9xx_pmu_ctr_enable_irq(uint32_t ctr_idx)
 
 static void thead_c9xx_pmu_ctr_disable_irq(uint32_t ctr_idx)
 {
+	csr_clear(THEAD_C9XX_CSR_MCOUNTERWEN, BIT(ctr_idx));
 	csr_clear(THEAD_C9XX_CSR_MCOUNTERINTEN, BIT(ctr_idx));
 }
 


### PR DESCRIPTION
These patches fix the system hang issue caused by using perf tool on
T-HEAD c9xx related platforms.

When detecting features of PMU, MHPMCOUNTER3 is changed to 0xffffffffffffffff
in the function hart_mhpm_get_allowed_bits. Enabling the counter directly
would cause an overflow interrupt. The correct procedure is to initialize
the counter's initial value before enabling the counter to count.
