### PR TITLE
platform: generic: thead: add sfence workaroud for th1520/sg2042

### DIFF
--- a/firmware/fw_base.S
+++ b/firmware/fw_base.S
@@ -757,7 +757,14 @@ memcmp:
 	.globl _trap_handler
 	.globl _trap_exit
 _trap_handler:
-	sfence.vma	zero, t0
+	/* add a pile for sfence workaround */
+	.option push
+	.option norvc
+	.option norelax
+
+	nop
+
+	.option pop
 
 	TRAP_SAVE_AND_SETUP_SP_T0
 

--- a/platform/generic/sophgo/objects.mk
+++ b/platform/generic/sophgo/objects.mk
@@ -4,3 +4,4 @@
 
 carray-platform_override_modules-$(CONFIG_PLATFORM_SOPHGO_MANGO) += sophgo_mango
 platform-objs-$(CONFIG_PLATFORM_SOPHGO_MANGO) += sophgo/mango.o
+platform-objs-$(CONFIG_PLATFORM_SOPHGO_MANGO) += sophgo/thead-patch.o

--- a/platform/generic/sophgo/thead-patch.S
+++ b/platform/generic/sophgo/thead-patch.S
@@ -1,0 +1,28 @@
+/*
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Authors:
+ *   Inochi Amaoto <inochiama@outlook.com>
+ *
+ */
+
+#include <sbi/riscv_elf.h>
+
+	.section .entry, "ax", %progbits
+	.align 3
+	.globl thead_patch_sfence
+thead_patch_sfence:
+	.option push
+	.option norvc
+	.option norelax
+
+	sfence.vma zero, t0
+
+	.option pop
+.equ _thead_patch_sfence_size, . - thead_patch_sfence
+
+	.section .rodata
+	.align 3
+	.globl thead_patch_sfence_size
+thead_patch_sfence_size:
+	RISCV_INT	_thead_patch_sfence_size


### PR DESCRIPTION
As the mmu of T-HEAD th1520 and Sophgo sg2042 is still functional after switching opensbi, so they need to execute sfence.vma in the trap handler to function properly.

To handle this workaroud, add a degraded alternative mechanism in the thead platform to patch the trap handler.