### PR TITLE
SOPHGO: SG2042: Fix up timer init error

### DIFF
--- a/platform/generic/sophgo/sg2042.c
+++ b/platform/generic/sophgo/sg2042.c
@@ -19,7 +19,7 @@
 
 #define SOPHGO_SG2042_TIMER_BASE	0x70ac000000ULL
 #define SOPHGO_SG2042_TIMER_SIZE	0x10000UL
-#define SOPHGO_SG2042_TIMER_NUM		16
+#define SOPHGO_SG2042_TIMER_NUM		32
 
 static int sophgo_sg2042_early_init(bool cold_boot)
 {
@@ -32,7 +32,7 @@ static int sophgo_sg2042_early_init(bool cold_boot)
 	thead_register_tlb_flush_trap_handler();
 
 	/*
-	 * Sophgo sg2042 soc use separate 16 timers while initiating,
+	 * Sophgo sg2042 soc use separate 16/32 timers while initiating,
 	 * merge them as a single domain to avoid wasting.
 	 */
 	if (cold_boot)


### PR DESCRIPTION
Timer init failed with the following error message in Pisces. Add 16 timers memrange(the default number) in sg2042_early_init while Pisces pruduct has 32 timers.

sbi_domain_root_add_memrange: line 678, 0x70ac1b4000,0x1000,0x80000003
sbi_domain_root_add_memrange: line 678, 0x70ac1b5000,0x1000,0x80000003
sbi_domain_root_add_memrange: line 678, 0x70ac1b6000,0x1000,0x80000003
sbi_domain_root_add_memrange: line 678, 0x70ac1b7000,0x1000,0x80000003
sbi_domain_root_add_memrange: line 678, 0x70ac1b8000,0x1000,0x80000003
sbi_domain_root_add_memrange: line 678, 0x70ac1b9000,0x1000,0x80000003
sbi_domain_root_add_memrange: line 678, 0x70ac1ba000,0x1000,0x80000003
sbi_domain_root_add_memrange: line 678, 0x70ac1bb000,0x1000,0x80000003
fdt_driver_init_by_offset: timer@70ac1b4000 (thead,c900-aclint-mtimer) init failed: -3
init_coldboot: timer init failed (error -3)